### PR TITLE
Inclusão das atualizações e correções de https://github.com/ericbrasiln/ferramentas_scielo_v2/pull/7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# scielo directory with results
+scielo/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/revistas.py
+++ b/revistas.py
@@ -6,7 +6,7 @@ from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.support.ui import WebDriverWait 
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.chrome.service import Service
-from webdriver_manager.firefox import GeckoDriverManager
+#from webdriver_manager.firefox import GeckoDriverManager
 
 def revistas (diretorio, link, link_journal, journal_name, saveMode):
     '''
@@ -17,8 +17,9 @@ def revistas (diretorio, link, link_journal, journal_name, saveMode):
     firefox_options.add_argument("--headless")
     firefox_options.add_argument("--no-sandbox")
     firefox_options.add_argument("--start-maximized")
-    s=Service(GeckoDriverManager().install())
-    driver = webdriver.Firefox(service=s, options=firefox_options)
+    #s=Service(GeckoDriverManager().install())
+    #driver = webdriver.Firefox(service=s, options=firefox_options)
+    driver = webdriver.Firefox(options=firefox_options)
     driver.get(link_journal)
     #Botão de aceitar cookies
     try:
@@ -39,3 +40,5 @@ def revistas (diretorio, link, link_journal, journal_name, saveMode):
         issue_link = issue.get_attribute("href")
         print(f'\nLink da edição: {issue_link}')
         get_issue(diretorio, link, issue_link, pasta, saveMode)
+    # Fechando o navegador
+    driver.quit()

--- a/scielo_rev_v2.py
+++ b/scielo_rev_v2.py
@@ -4,6 +4,7 @@ from revistas import revistas
 
 timestr = time.strftime("%Y-%m-%d")
 saveMode = ''
+
 def main():
     global saveMode
     while (saveMode != 1 and saveMode != 2):

--- a/scielo_v2.py
+++ b/scielo_v2.py
@@ -2,7 +2,6 @@ from revistas import revistas
 from reports import report_scrape
 import time, os
 from selenium import webdriver
-from webdriver_manager.firefox import GeckoDriverManager
 from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.support.ui import WebDriverWait 
@@ -11,6 +10,7 @@ from selenium.webdriver.chrome.service import Service
 
 timestr = time.strftime("%Y-%m-%d")
 saveMode = ''
+
 def main():
     global saveMode
     while (saveMode != 1 and saveMode != 2):
@@ -43,8 +43,7 @@ def main():
         firefox_options.add_argument("--headless")
         firefox_options.add_argument("--no-sandbox")
         firefox_options.add_argument("--start-maximized")
-        s=Service(GeckoDriverManager().install())
-        driver = webdriver.Firefox(service=s, options=firefox_options)
+        driver = webdriver.Firefox(options=firefox_options)
         driver.get(url)
         #botão de aceitar cookies
         try:
@@ -53,6 +52,13 @@ def main():
             WebDriverWait(driver, 10).until(EC.element_to_be_clickable(
                 (By.XPATH, '/html/body/div[6]/a[2]')
                 )).click()
+        except:
+            pass
+        # set locale for pt: find element by xpath and try to find element by class name
+        locale_div = driver.find_element(By.XPATH, '/html/body/header/div/div/div[3]')
+        # try to find element by class name and click it if found
+        try:
+            local_pt = locale_div.find_element(By.CLASS_NAME, 'lang-pt').click()
         except:
             pass
         journal_table = driver.find_element(By.ID,'journals_table_body')


### PR DESCRIPTION
- `.gitignore` [Inclusão da pasta /scielo no .gitignore](https://github.com/ericbrasiln/ferramentas_scielo_v2/commit/f53fabbf95b1f0d59e8552a934f6db9d26dd395c): Pasta de resultados de raspagens /scielo incluída no .gitignore
- `scielo_rev_v2.py` [Inclusão de linha em branco antes da função](https://github.com/ericbrasiln/ferramentas_scielo_v2/commit/bcf6b18a16f23b36ef15cbd95828b0b73edef348)
- `scielo_v2.py` [Correção do webdriver e correção de idioma da pág](https://github.com/ericbrasiln/ferramentas_scielo_v2/commit/e19df330f8de1aa4aee5f959ad6df1ac9932f047):
   - Exclusão do webdriver manager, pois ele retornava erro após 60 downloads.
   - Exclusão do comando para não imprimir logs do webdriver manager
   - Inclusão da opção do próprio selenium para evocar o webdriver;
   - Inclusão de try/except para testar se a página carregada está em pt
- `revistas.py` [Correção do driver, comando para fechar o driver](https://github.com/ericbrasiln/ferramentas_scielo_v2/commit/7d172c032212da21569e5fb204bbca38ad7fd886)
    - Exclusão do webdriver manager, pois ele retornava erro após 60 downloads.
    - Exclusão do comando para não imprimir logs do webdriver manager
    - Inclusão od comando para fechar o driver após a iteração
- `issue_xml.py` [Correção do driver, find h1, driver.quit()](https://github.com/ericbrasiln/ferramentas_scielo_v2/commit/c2cdeff8617a49e922c98aca3e4e4cb8a029bbd1)
    - Exclusão do webdriver manager, pois ele retornava erro após 60 downloads.
    - Exclusão do comando para não imprimir logs do webdriver manager
    - inclusão de try/except para buscar o h1 na página (pois algumas página aop existem, mas sem nenhuma edição publicada, o que gerava erro pois não era possível encontrar os dados, como pontuado por usuário na issue https://github.com/ericbrasiln/ferramentas_scielo_v2/issues/4
    - Inclusão do comando driver.quit() ao final da iteração